### PR TITLE
Make remind101/conveyor-builder backwards compatible.

### DIFF
--- a/builder/docker/Makefile
+++ b/builder/docker/Makefile
@@ -19,15 +19,15 @@ bootstrap: build data
 build:
 	docker build -t ${IMAGE} .
 
-data: data/.dockercfg data/.ssh/id_rsa
+data: data/.docker/config.json data/.ssh/id_rsa
 	docker rm data || true
 	docker create --name data \
 		-v ${PWD}/data/.ssh:/var/run/conveyor/.ssh \
-		-v ${PWD}/data/.dockercfg:/var/run/conveyor/.dockercfg \
+		-v ${PWD}/data/.docker/config.json:/var/run/conveyor/.docker/config.json \
 		alpine:3.1 sh
 
-data/.dockercfg:
-	cp ${HOME}/.dockercfg data/.dockercfg
+data/.docker/config.json:
+	cp ${HOME}/.docker/config.json data/.docker/config.json
 
 data/.ssh/id_rsa:
 	ssh-keygen -t rsa -b 4096 -C ${EMAIL} -f data/.ssh/id_rsa -P ""

--- a/builder/docker/bin/build
+++ b/builder/docker/bin/build
@@ -59,8 +59,12 @@ setup() {
   chmod -R 0600 ~/.ssh
   ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
 
-  # Copy .docker/config.json from the data volume.
-  cp -r /var/run/conveyor/.docker/config.json /root/.docker/config.json
+  # Copy .docker/config.json from the data volume. Fallback to old .dockercfg.
+  if [ -d /var/run/conveyor/.docker ]; then
+    cp -r /var/run/conveyor/.docker /root/.docker
+  else
+    cp -r /var/run/conveyor/.dockercfg /root/.dockercfg
+  fi
 
   status "Starting Docker..."
   wrapdocker


### PR DESCRIPTION
This will allow the builder to fallback to .dockercfg (favoring .docker/config.json), which makes it backwards compatible with current conveyor installations.
